### PR TITLE
Changed the required node version to 0.6.3 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/jherdman/airship/issues"
   },
   "engines": {
-    "node": "~0.6.10"
+    "node": "~0.6.3"
   },
   "dependencies": {
   },


### PR DESCRIPTION
Changed the required node version to 0.6.3 as it is known to work for the same version.
