### PR TITLE
Add correct header to use with UA API v3

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -106,6 +106,7 @@ Request.prototype.apiCall = function (data) {
 
     req.setHeader('content-type', 'application/json');
     req.setHeader('content-length', encodedData.length);
+    req.setHeader('Accept', 'application/vnd.urbanairship+json; version=3');
 
     req.end(encodedData, 'utf8');
   } else {


### PR DESCRIPTION
Without this header you get errors like "nothing to deliver to (missing device_tokens, tags, segments, or aliases)" if you want to use newer stuff like the "audience" parameter.
